### PR TITLE
Dependency check for aircrack-ng

### DIFF
--- a/aircrackonly.py
+++ b/aircrackonly.py
@@ -47,6 +47,7 @@ class AircrackOnly(plugins.Plugin):
         if todelete == 1:
             os.remove(filename)
             self.text_to_set = "Removed an uncrackable pcap"
+            logging.warning("Removed uncrackable pcap " + filename)
             display.update(force=True)
 
     def on_ui_update(self, ui):

--- a/aircrackonly.py
+++ b/aircrackonly.py
@@ -22,6 +22,13 @@ class AircrackOnly(plugins.Plugin):
 
     def on_loaded(self):
         logging.info("aircrackonly plugin loaded")
+        check = subprocess.run(
+            ('/usr/bin/dpkg -l aircrack-ng | grep aircrack-ng | awk \'{print $2, $3}\''), shell=True, stdout=subprocess.PIPE)
+        check = check.stdout.decode('utf-8').strip()
+        if check != "aircrack-ng <none>":
+            logging.info("aircrackonly: Found " + check)
+        else:
+            logging.warning("aircrack-ng is not installed!")
 
     def on_handshake(self, agent, filename, access_point, client_station):
         display = agent._view

--- a/quickdic.py
+++ b/quickdic.py
@@ -8,7 +8,7 @@ import pwnagotchi.plugins as plugins
 Aircrack-ng needed, to install:
 > apt-get install aircrack-ng
 Upload wordlist files in .txt format to folder in config file (Default: /opt/wordlists/)
-Cracked handshakes stored in handshake folder as [essid].pcap.cracked 
+Cracked handshakes stored in handshake folder as [essid].pcap.cracked
 '''
 
 
@@ -23,6 +23,13 @@ class QuickDic(plugins.Plugin):
 
     def on_loaded(self):
         logging.info("Quick dictionary check plugin loaded")
+        check = subprocess.run(
+            ('/usr/bin/dpkg -l aircrack-ng | grep aircrack-ng | awk \'{print $2, $3}\''), shell=True, stdout=subprocess.PIPE)
+        check = check.stdout.decode('utf-8').strip()
+        if check != "aircrack-ng <none>":
+            logging.info("quickdic: Found " + check)
+        else:
+            logging.warning("aircrack-ng is not installed!")
 
     def on_handshake(self, agent, filename, access_point, client_station):
         display = agent.view()
@@ -35,7 +42,7 @@ class QuickDic(plugins.Plugin):
             logging.info("[quickdic] Handshake confirmed")
             result2 = subprocess.run(('aircrack-ng -w `echo ' + self.options[
                 'wordlist_folder'] + '*.txt | sed \'s/\ /,/g\'` -l ' + filename + '.cracked -q -b ' + result + ' ' + filename + ' | grep KEY'),
-                                     shell=True, stdout=subprocess.PIPE)
+                shell=True, stdout=subprocess.PIPE)
             result2 = result2.stdout.decode('utf-8').strip()
             logging.info("[quickdic] " + result2)
             if result2 != "KEY NOT FOUND":


### PR DESCRIPTION
- aircrackonly & quickdic check that aircrack-ng is installed else log warning
- Log warning including filename when aircrackonly deletes uncrackable pcap