### PR TITLE
Add face option in aircrackonly & quickdic plugins

### DIFF
--- a/aircrackonly.py
+++ b/aircrackonly.py
@@ -22,6 +22,10 @@ class AircrackOnly(plugins.Plugin):
 
     def on_loaded(self):
         logging.info("aircrackonly plugin loaded")
+
+        if 'face' not in self.options:
+            self.options['face'] = '(>.<)'
+
         check = subprocess.run(
             ('/usr/bin/dpkg -l aircrack-ng | grep aircrack-ng | awk \'{print $2, $3}\''), shell=True, stdout=subprocess.PIPE)
         check = check.stdout.decode('utf-8').strip()
@@ -59,6 +63,6 @@ class AircrackOnly(plugins.Plugin):
 
     def on_ui_update(self, ui):
         if self.text_to_set:
-            ui.set('face', "(>.<)")
+            ui.set('face', self.options['face'])
             ui.set('status', self.text_to_set)
             self.text_to_set = ""

--- a/aircrackonly.yml
+++ b/aircrackonly.yml
@@ -1,2 +1,3 @@
 aircrackonly:
     enabled: false
+    face: '(>.<)'

--- a/quickdic.py
+++ b/quickdic.py
@@ -23,6 +23,10 @@ class QuickDic(plugins.Plugin):
 
     def on_loaded(self):
         logging.info("Quick dictionary check plugin loaded")
+
+        if 'face' not in self.options:
+            self.options['face'] = '(·ω·)'
+
         check = subprocess.run(
             ('/usr/bin/dpkg -l aircrack-ng | grep aircrack-ng | awk \'{print $2, $3}\''), shell=True, stdout=subprocess.PIPE)
         check = check.stdout.decode('utf-8').strip()
@@ -54,6 +58,6 @@ class QuickDic(plugins.Plugin):
 
     def on_ui_update(self, ui):
         if self.text_to_set:
-            ui.set('face', "(·ω·)")
+            ui.set('face', self.options['face'])
             ui.set('status', self.text_to_set)
             self.text_to_set = ""

--- a/quickdic.yml
+++ b/quickdic.yml
@@ -1,3 +1,4 @@
 quickdic:
     enabled: false
     wordlist_folder: /opt/wordlists/
+    face: '(·ω·)'


### PR DESCRIPTION
Allows setting custom faces in AircrackOnly plugin when a pcap is deleted and in Quickdic when a password is cracked.
Using a yaml key `face:` under the plugin entry, faces can be added as strings:
```yaml
plugins:
  aircrackonly:
    enabled: true
    face: '(>__<)'
```
This key is optional and not including it will just fall back on hardcoded face, however I have included it in example .yml files in place of documentation.