### PR TITLE
Enable custom time format for clock.py in config

### DIFF
--- a/clock.py
+++ b/clock.py
@@ -12,15 +12,23 @@ import yaml
 
 class PwnClock(plugins.Plugin):
     __author__ = 'https://github.com/LoganMD'
-    __version__ = '1.0.2'
+    __version__ = '1.0.3'
     __license__ = 'GPL3'
     __description__ = 'Clock/Calendar for pwnagotchi'
+    __defaults__ = {
+        'enabled': False,
+    }
 
     def on_loaded(self):
         if 'date_format' in self.options:
             self.date_format = self.options['date_format']
         else:
             self.date_format = "%m/%d/%y"
+
+        if 'time_format' in self.options:
+            self.time_format = self.options['time_format']
+        else:
+            self.time_format = "%I:%M %p"
 
         logging.info("Pwnagotchi Clock Plugin loaded.")
 
@@ -47,5 +55,5 @@ class PwnClock(plugins.Plugin):
 
     def on_ui_update(self, ui):
         now = datetime.datetime.now()
-        time_rn = now.strftime(self.date_format + "\n%I:%M %p")
+        time_rn = now.strftime(self.date_format + "\n" + self.time_format)
         ui.set('clock', time_rn)

--- a/clock.toml
+++ b/clock.toml
@@ -1,0 +1,3 @@
+main.plugins.clock.enabled = "true"
+main.plugins.clock.date_format = "%d/%m/%y"
+main.plugins.clock.time_format = "%H:%M"


### PR DESCRIPTION
These changes allow you to customise the displayed time format by editing **config.toml**, e.g. switching from 12 to 24 hours clock format, or adding seconds (in the same fashion as @xBelladonna added the date formatting).

`main.plugins.clock-niu.enabled = "true"`
`main.plugins.clock-niu.date_format = "%Y%m%d"`
`main.plugins.clock-niu.time_format = "%H:%M:%S"`

If no custom format is set, clock.py will revert to its default formats.

![pwnagotchi-clock-plugin-screenshot001](https://user-images.githubusercontent.com/20810263/105899671-40a6f880-601b-11eb-92e3-d4a4bd9bc10f.jpg)

