### PR TITLE
Add display_version plugin that shows the Pwnagotchi version

### DIFF
--- a/display_version.py
+++ b/display_version.py
@@ -1,0 +1,32 @@
+from pwnagotchi.ui.components import LabeledValue
+from pwnagotchi.ui.view import BLACK
+import pwnagotchi.plugins as plugins
+import pwnagotchi.ui.fonts as fonts
+import pwnagotchi
+import logging
+
+
+class PwnagotchiVersion(plugins.Plugin):
+    __author__ = 'https://github.com/Teraskull/'
+    __version__ = '1.0.0'
+    __license__ = 'GPL3'
+    __description__ = 'A plugin that will add the Pwnagotchi version to the left of the current mode.'
+
+    def on_loaded(self):
+        logging.info('Pwnagotchi Version Plugin loaded.')
+
+    def on_ui_setup(self, ui):
+        ui.add_element(
+            'version',
+            LabeledValue(
+                color=BLACK,
+                label='',
+                value='v0.0.0',
+                position=(185, 110),
+                label_font=fonts.Small,
+                text_font=fonts.Small
+            )
+        )
+
+    def on_ui_update(self, ui):
+        ui.set('version', f'v{pwnagotchi.__version__}')

--- a/display_version.toml
+++ b/display_version.toml
@@ -1,0 +1,1 @@
+main.plugins.display_version.enabled = false


### PR DESCRIPTION
The display position:

![image](https://user-images.githubusercontent.com/24798198/129402445-fd62d6a8-d710-4dc1-87a9-ae593a61b040.png)

To install/enable the plugin:

Download the `display_version.py` into the default plugin location:
```
/usr/local/share/pwnagotchi/installed-plugins/
```
Add the following line to your `config.toml`:
```toml
main.plugins.display_version.enabled = true
```

