### PR TITLE
Update mastodon.py

### DIFF
--- a/mastodon.py
+++ b/mastodon.py
@@ -75,3 +75,5 @@ class MastodonStatus(plugins.Plugin):
                     self.post_to_mastodon(agent, last_session, api_base_url, token, visibility)
                 except Exception as post_exception:
                     logging.error("[mastodon] Error while posting: %s" % str(post_exception))
+        except Exception as on_internet_available:
+                    logging.error("[mastodon] Error while initiating on_internet_available: %s" % str(on_internet_available))

--- a/mastodon.py
+++ b/mastodon.py
@@ -5,61 +5,45 @@ import pwnagotchi.plugins as plugins
 try:
     from mastodon import Mastodon
 except ImportError:
-    logging.error('Could not import mastodon')
-
+    logging.error('[mastodon] Could not import mastodon')
 
 class MastodonStatus(plugins.Plugin):
-    __author__ = 'siina@siina.dev'
-    __version__ = '1.0.0'
+    __author__ = 'retiolus'
+    __version__ = '2.0.0'
     __license__ = 'GPL3'
-    __description__ = 'Periodically post status updates. Based on twitter plugin by evilsocket'
+    __description__ = '''
+                    Periodically post status updates. Based on original Mastodon plugin by siina@siina.dev.
+                    To use this plugin make sure Mastodon.py library is installed using "sudo pip install Mastodon.py"
+                    Don't forget do add the following options in your config:
+                    main.plugins.mastodon.enabled = True
+                    main.plugins.mastodon.instance_url = https://your-instance.com
+                    main.plugins.mastodon.token = your-generated-token
+                    main.plugins.mastodon.visibility = unlisted
+                    Enjoy!'''
 
     def on_loaded(self):
-        logging.info("mastodon plugin loaded.")
+        try:
+            logging.info("[mastodon] mastodon plugin loaded.")
+        except Exception as e:
+            logging.error("[mastodon] Error loading plugin: %s" % str(e))
 
-    # Called when there's available internet
-    def on_internet_available(self, agent):
-        config = agent.config()
-        display = agent.view()
-        last_session = agent.last_session
-        api_base_url = self.options['instance_url']
-        email = self.options['email']
-        password = self.options['password']
-        visibility = self.options['visibility']
-        client_cred = '/root/.mastodon.client.secret'
-        user_cred = '/root/.mastodon.user.secret'
-
-        if last_session.is_new() and last_session.handshakes > 0:
-            logging.info("Detected internet and new activity: time to post!")
-
-            if not os.path.isfile(user_cred) or not os.path.isfile(client_cred):
-                # Runs only if there are any missing credential files
-                Mastodon.create_app(
-                    config['main']['name'],
-                    api_base_url=api_base_url,
-                    to_file=client_cred
-                )
+    def post_to_mastodon(self, agent, last_session, api_base_url, token, visibility):
+        try:
             picture = '/root/pwnagotchi.png'
+            display = agent.view()
+            config = agent.config()
             display.on_manual_mode(last_session)
             display.image().save(picture, 'png')
             display.update(force=True)
 
             try:
-                logging.info('Connecting to Mastodon API')
+                logging.info('[mastodon] Connecting to Mastodon API')
                 mastodon = Mastodon(
-                    client_id=client_cred,
-                    api_base_url=api_base_url
-                )
-                mastodon.log_in(
-                    email,
-                    password,
-                    to_file=user_cred
-                )
-                mastodon = Mastodon(
-                    access_token=user_cred,
+                    access_token=token,
                     api_base_url=api_base_url
                 )
                 message = Voice(lang=config['main']['lang']).on_last_session_tweet(last_session)
+                logging.info("[mastodon] Posting status on Mastodon")
                 mastodon.status_post(
                     message,
                     media_ids=mastodon.media_post(picture),
@@ -67,8 +51,27 @@ class MastodonStatus(plugins.Plugin):
                 )
 
                 last_session.save_session_id()
-                logging.info("posted: %s" % message)
+                logging.info("[mastodon] Posted: %s" % message)
                 display.set('status', 'Posted!')
                 display.update(force=True)
-            except Exception:
-                logging.exception("error while posting")
+            except Exception as mastodon_exception:
+                logging.error("[mastodon] Error while posting to Mastodon: %s" % str(mastodon_exception))
+        except Exception as post_exception:
+            logging.error("[mastodon] Error while posting: %s" % str(post_exception))
+
+    # Called when there's available internet
+    def on_internet_available(self, agent):
+        try:
+            config = agent.config()
+            last_session = agent.last_session
+            api_base_url = self.options['instance_url']
+            token = self.options['token']
+            visibility = self.options['visibility']
+            
+            if last_session.is_new() and last_session.handshakes > 0:
+                logging.info("[mastodon] Detected internet and new activity: time to post!")
+
+                try:
+                    self.post_to_mastodon(agent, last_session, api_base_url, token, visibility)
+                except Exception as post_exception:
+                    logging.error("[mastodon] Error while posting: %s" % str(post_exception))

--- a/mastodon.yml
+++ b/mastodon.yml
@@ -2,5 +2,4 @@ mastodon:
   enabled: false
   instance_url: ~
   visibility: unlisted
-  email: ~
-  password: ~
+  token: ~


### PR DESCRIPTION
Update and reformatting of the plugin, which was no longer working, was not optimised and did not provide enough information in the logs.

Among other things, it no longer uses the Mastodon account username and password, but a token that must be generated on the Mastodon account configuration interface.